### PR TITLE
Bump gbp-docker to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Calendar Versioning](https://calver.org/).
 ## Added
 - Ability to set container name with `$CNAME` environment variable
 
+### Changed
+- Local package index is now stored separately from packages
+
+### Fixed
+- Parallel containers conflicting when writing package indexes
+
 ## [18.10.6] - 2018/10/23
 ### Fixed
 - Debuild now uses `~/.devscripts` instead of hard-coding flags

--- a/dbp.py
+++ b/dbp.py
@@ -17,7 +17,7 @@ import controlgraph
 import networkx as nx
 
 IMAGE = "opxhub/gbp"
-IMAGE_VERSION = "v2.0.2"
+IMAGE_VERSION = "v2.0.3"
 if "CNAME" in os.environ:
     CONTAINER_NAME = os.getenv("CNAME")
 else:


### PR DESCRIPTION
* Store package index separately from package files

Signed-off-by: Tyler Heucke <tyler@heucke.io>