### PR TITLE
Run the entrypoint directly on exec

### DIFF
--- a/dbp.py
+++ b/dbp.py
@@ -119,12 +119,12 @@ class Workspace:
             "docker",
             "exec",
             "-it" if self.interactive else "-t",
-            "--user=build",
             "--workdir={}".format(workdir),
         ]
         for k, v in self.env.items():
             full_cmd.append("-e={}={}".format(k, v))
         full_cmd.append(self.cname)
+        full_cmd.append("/entrypoint.sh")
         full_cmd.extend(command)
 
         proc = subprocess.run(
@@ -163,14 +163,9 @@ class Workspace:
             stdin_open=sys.stdin.isatty(),
             tty=True,
             volumes=self.volumes,
+            entrypoint="bash",
+            command=[],
         )
-
-        # wait until entrypoint has run and our user is created
-        sleep(0.1)
-        while self.container.status != "running":
-            info(".", nl=False)
-            sleep(0.5)
-            self.container.reload()
         info("Done!")
 
         return True


### PR DESCRIPTION
Relying on the Docker API to report the container status as running
does not guarantee that the entrypoint has finished running. The
entrypoint is a no-op if the user build already exists, so this will
only slow down the initial exec slightly. But hey, it's better than a
failure to launch!

Signed-off-by: Tyler Heucke <tyler.heucke@dell.com>